### PR TITLE
bindStateValue: get correct val when bindState type is Boolean but type of val is String

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,9 +22,12 @@ class BindingComponent extends React.Component {
    */
   set bindStateValue(val) {
     if (typeof this.props.bindStateType === 'function') {
-      val = this.props.bindStateType(val);
       if (this.props.bindStateType === Number && isNaN(val)) {
         val = 0;
+      } else if (this.props.bindStateType === Boolean && typeof val === 'string') {
+        val = (val === 'true') ? true : false;
+      } else {
+        val = this.props.bindStateType(val);
       }
     }
     const names = this.props.bindStateName.split('.');


### PR DESCRIPTION
R= @yorkie please review thank you.

Related PR: https://github.com/weflex/studio-desktop/pull/265

update:
- when bind element is `<select>` and value of `<option>` is Boolean, the value will be change to String by `<option>`, because typeof `<option>`'s value is DOMString. so I add the deal to this.
