### PR TITLE
Promote more readable code

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
   "bugs": {
     "url": "https://github.com/weflex/react-binding-component/issues"
   },
-  "homepage": "https://github.com/weflex/react-binding-component#readme"
+  "homepage": "https://github.com/weflex/react-binding-component#readme",
+  "dependencies": {
+    "deep-assign": "2.0.0"
+  }
 }


### PR DESCRIPTION
R= @yorkie @zhangweijie-cn 

**Notable Changes**
- Promote more readable code for _set bindStateName_
  - Avoid unnecessary branching;
  - Avoid messing with indexes and assigning;
  - Avoid wiping out sub-states by using [_deep-assign_](https://github.com/sindresorhus/deep-assign);
  - Capture error case and handle it properly (e.g. return a proper fallback value);
- Unify coding style setting and getting _bindStateName_
